### PR TITLE
:sparkles: Display all players in same room

### DIFF
--- a/src/pages/game.js
+++ b/src/pages/game.js
@@ -146,6 +146,7 @@ class SecondPage extends Component {
         if (this.state.error_msg) {
           this.setState({ error_msg: "" })
         }
+        this.setState({ players: res.data.players })
       })
       .catch(err => {
         console.log(err)
@@ -223,6 +224,7 @@ class SecondPage extends Component {
     })
 
     const GameRows = () =>
+      maze.length &&
       maze.map((row, row_i) =>
         row.map((cell, col_i) => (
           <GameSquare


### PR DESCRIPTION
Grabs new players array from BE on each move() action, sets on state and properly displays them in list. Updates on every move. Tested locally since it pairs with [# 18 on the frontend](https://github.com/cs19-build-week-1/backend/pull/18) but is not deployed yet. 
![image](https://user-images.githubusercontent.com/34550186/62377239-059c3580-b508-11e9-9f42-384d1be0d7d6.png)
